### PR TITLE
fix: Corrected Java distribution to 'temurin' in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'corretto'
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Build with Gradle


### PR DESCRIPTION
### Overview:
This PR fixes the issue in the GitHub Actions workflow where the 'corretto' Java distribution was not found, causing the build to fail. The distribution has been updated to 'temurin', which is a supported OpenJDK distribution.

### Key Changes:
- **Java Distribution Update**: Changed the Java distribution in `deploy.yml` from `corretto` to `temurin` to resolve the setup issue.
- **Build Process**: Ensures that JDK 17 is properly installed using the `temurin` distribution, enabling the Gradle build process to proceed as expected.