### PR TITLE
fix: Added Hibernate dialect and improved test environment configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // H2
+    testImplementation 'com.h2database:h2:2.3.232'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+      dialect: org.hibernate.dialect.MySQL8Dialect
     show-sql: true
     defer-datasource-initialization: true
   mvc:

--- a/src/test/java/com/neon/tamago/TamagoApplicationTests.java
+++ b/src/test/java/com/neon/tamago/TamagoApplicationTests.java
@@ -2,8 +2,10 @@ package com.neon.tamago;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class TamagoApplicationTests {
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
+    defer-datasource-initialization: true


### PR DESCRIPTION
### Overview:
This PR addresses the issue where the Spring Boot application tests were failing due to a missing Hibernate dialect configuration and database connection issues. The necessary configurations for the Hibernate dialect and test environment have been added to ensure that the tests run correctly.

### Key Changes:
- **Hibernate Dialect**: Added `org.hibernate.dialect.MySQL8Dialect` in the `application.yml` to ensure proper MySQL dialect handling in both runtime and test environments.
- **Test Profile with H2**: Introduced a `test` profile that uses an in-memory H2 database for running tests, avoiding direct dependencies on MySQL for simple context loading and integration tests.
- **Profile Configuration**: Updated `TamagoApplicationTests` to use the `test` profile, activating the H2 configuration to simplify testing and avoid real database dependency.