### PR TITLE
fix: Deploy pipeline with proper Gradle build and Dockerfile adjustments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      # Gradle 빌드
+      # Gradle 빌드 (JAR 파일 생성)
       - name: Build with Gradle
         run: ./gradlew clean build
 
@@ -31,10 +31,10 @@ jobs:
           echo "${{ secrets.EC2_KEY }}" > ~/ec2_key.pem
           chmod 600 ~/ec2_key.pem
 
-      # Docker Compose 파일과 Dockerfile을 EC2로 전송 (scp 사용)
+      # 빌드된 JAR 파일과 Docker Compose 파일을 EC2로 전송
       - name: Copy files to EC2
         run: |
-          scp -i ~/ec2_key.pem -o StrictHostKeyChecking=no docker-compose.yml Dockerfile ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:~/spring-app/
+          scp -i ~/ec2_key.pem -o StrictHostKeyChecking=no build/libs/*.jar docker-compose.yml Dockerfile ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:~/spring-app/
 
       # EC2에 SSH 접속하여 Docker Compose 실행
       - name: SSH and deploy with Docker Compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-# Base image
+# Base image with JDK 17
 FROM openjdk:17-jdk-slim
 
-# Set the working directory
+# Set working directory
 WORKDIR /app
 
-# Copy the build output from Gradle
-COPY build/libs/*.jar app.jar
+# Copy the build output (JAR file) from the host to the container
+COPY app.jar app.jar
 
-# Expose the port that the Spring app will run on
+# Expose the port on which the Spring app will run
 EXPOSE 8080
 
-# Run the Spring Boot application
+# Command to run the Spring Boot application
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
- Updated the GitHub Actions workflow to first build the Spring Boot application using Gradle.
- Ensured the generated JAR file is transferred to the EC2 instance along with Docker Compose files.
- Adjusted the Dockerfile to copy the JAR file directly, simplifying the Docker build process.
- Resolved errors related to missing JAR files during Docker build.